### PR TITLE
Updates scoreboard counters to resemble original minesweeper

### DIFF
--- a/src/components/BombsDisplay/BombsDisplay.jsx
+++ b/src/components/BombsDisplay/BombsDisplay.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+import { BombsBox, BombsImg } from "./BombsDisplay.styled";
+
+import counter_0 from "../../assets/counter_0.png";
+import counter_1 from "../../assets/counter_1.png";
+import counter_2 from "../../assets/counter_2.png";
+import counter_3 from "../../assets/counter_3.png";
+import counter_4 from "../../assets/counter_4.png";
+import counter_5 from "../../assets/counter_5.png";
+import counter_6 from "../../assets/counter_6.png";
+import counter_7 from "../../assets/counter_7.png";
+import counter_8 from "../../assets/counter_8.png";
+import counter_9 from "../../assets/counter_9.png";
+import counter_null from "../../assets/counter_null.png";
+
+const importedImage = {
+  counter_0,
+  counter_1,
+  counter_2,
+  counter_3,
+  counter_4,
+  counter_5,
+  counter_6,
+  counter_7,
+  counter_8,
+  counter_9,
+  counter_null,
+};
+
+// Turns to string to be able to add the 0's
+const stringFlaggedAmount = (flaggedAmount) => {
+  const stringfied = flaggedAmount.toString();
+  if (stringfied.length === 1) return "00" + flaggedAmount;
+  else if (stringfied.length === 2) return "0" + stringfied;
+  else return stringfied;
+};
+
+export const BombsDisplay = ({ flaggedAmount }) => {
+  return (
+    <BombsBox>
+      <BombsImg
+        src={
+          flaggedAmount < 0
+            ? counter_null
+            : importedImage[
+                `counter_${stringFlaggedAmount(flaggedAmount).charAt(0)}`
+              ]
+        }
+        alt={
+          flaggedAmount < 0
+            ? "-"
+            : importedImage[
+                `counter_${stringFlaggedAmount(flaggedAmount).charAt(0)}`
+              ]
+        }
+      />
+      <BombsImg
+        src={
+          flaggedAmount < 0 && flaggedAmount > -10
+            ? importedImage[`counter_0`]
+            : importedImage[
+                `counter_${stringFlaggedAmount(flaggedAmount).charAt(1)}`
+              ]
+        }
+        alt={
+          flaggedAmount < 0 && flaggedAmount > -10
+            ? "0"
+            : importedImage[
+                `counter_${stringFlaggedAmount(flaggedAmount).charAt(1)}`
+              ]
+        }
+      />
+      <BombsImg
+        src={
+          importedImage[
+            `counter_${stringFlaggedAmount(flaggedAmount).charAt(2)}`
+          ]
+        }
+        alt={
+          importedImage[
+            `counter_${stringFlaggedAmount(flaggedAmount).charAt(3)}`
+          ]
+        }
+      />
+    </BombsBox>
+  );
+};

--- a/src/components/BombsDisplay/BombsDisplay.styled.js
+++ b/src/components/BombsDisplay/BombsDisplay.styled.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+import { Box } from "../Box";
+
+export const BombsBox = styled(Box)`
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: black;
+  padding: 0.5%;
+`;
+
+export const BombsImg = styled.img`
+  height: calc(100% - 4px);
+  margin: 0 2px;
+  image-rendering: pixelated;
+`;

--- a/src/components/Cell/Cell.jsx
+++ b/src/components/Cell/Cell.jsx
@@ -20,7 +20,6 @@ export const Cell = ({
       draggable="false"
     >
       {toDisplay(cellArray, index, value)}
-      {console.log(`Cell re renderIntoDocument`)}
     </CellStyled>
   );
 };

--- a/src/components/Scoreboard/Scoreboard.jsx
+++ b/src/components/Scoreboard/Scoreboard.jsx
@@ -2,13 +2,20 @@ import React from "react";
 
 import { Timer } from "../Timer/Timer";
 
-import { ScoreboardBox } from "./ScoreboardBox";
+import { ScoreboardBox, BombsBox } from "./ScoreboardBox.styled";
 
 import { Box } from "../Box/";
 
 export const Scoreboard = ({ statusHandler, gameStatus, flaggedAmount }) => {
   return (
     <ScoreboardBox>
+      <BombsBox>
+        <Box>
+          {/* flag Icon */}
+          <Box margin={"0 5px 0 0"} />
+          <Box>{flaggedAmount}</Box>
+        </Box>
+      </BombsBox>
       {/* Reset Icon */}
       <Box
         onClick={() => {
@@ -16,16 +23,13 @@ export const Scoreboard = ({ statusHandler, gameStatus, flaggedAmount }) => {
         }}
         className="fas fa-redo-alt"
       />
-      <Box>
-        {/* clock Icon */}
-        <Box className="far fa-clock fa-lg" margin={"0 5px 0 0"} />
-        <Timer gameStatus={gameStatus} />
-      </Box>
-      <Box>
-        {/* flag Icon */}
-        <Box className="far fa-flag fa-lg" margin={"0 5px 0 0"} />
-        <Box>{flaggedAmount}</Box>
-      </Box>
+      <BombsBox>
+        <Box>
+          {/* clock Icon */}
+          <Box margin={"0 5px 0 0"} />
+          <Timer gameStatus={gameStatus} />
+        </Box>
+      </BombsBox>
     </ScoreboardBox>
   );
 };

--- a/src/components/Scoreboard/Scoreboard.jsx
+++ b/src/components/Scoreboard/Scoreboard.jsx
@@ -1,35 +1,27 @@
 import React from "react";
 
+import { BombsDisplay } from "../BombsDisplay/BombsDisplay";
+
 import { Timer } from "../Timer/Timer";
 
-import { ScoreboardBox, BombsBox } from "./ScoreboardBox.styled";
+import { ScoreboardBox } from "./ScoreboardBox.styled";
 
-import { Box } from "../Box/";
+import face_waiting from "../../assets/face_waiting.png";
 
 export const Scoreboard = ({ statusHandler, gameStatus, flaggedAmount }) => {
   return (
     <ScoreboardBox>
-      <BombsBox>
-        <Box>
-          {/* flag Icon */}
-          <Box margin={"0 5px 0 0"} />
-          <Box>{flaggedAmount}</Box>
-        </Box>
-      </BombsBox>
+      <BombsDisplay flaggedAmount={flaggedAmount} />
       {/* Reset Icon */}
-      <Box
+      <img
+        src={face_waiting}
+        alt={"reset"}
         onClick={() => {
           statusHandler("waiting");
         }}
-        className="fas fa-redo-alt"
+        style={{ height: "100%", imageRendering: "pixelated" }}
       />
-      <BombsBox>
-        <Box>
-          {/* clock Icon */}
-          <Box margin={"0 5px 0 0"} />
-          <Timer gameStatus={gameStatus} />
-        </Box>
-      </BombsBox>
+      <Timer gameStatus={gameStatus} />
     </ScoreboardBox>
   );
 };

--- a/src/components/Scoreboard/ScoreboardBox.styled.js
+++ b/src/components/Scoreboard/ScoreboardBox.styled.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { Box } from "../Box/";
+import { Box } from "../Box";
 
 export const ScoreboardBox = styled(Box)`
   justify-content: space-between;
@@ -11,8 +11,15 @@ export const ScoreboardBox = styled(Box)`
   color: white;
   width: calc(100% - (100% * 0.06)); // amount added in margin
   height: 15%;
-  padding: 0 3%;
+  padding: 1.5%;
   border: inset 10px hsl(0deg 0% 92%);
   margin: calc(85% * 0.03) calc(100% * 0.03) 0 calc(100% * 0.03); // to be equal to the board
   background-color: hsl(0, 0%, 75%);
+`;
+
+export const BombsBox = styled(Box)`
+  // 100 * 1.15 to get 100% of the height and then * 1.6956 as that is the ratio 78:46.
+  width: calc(((100% * 1.15) * 0.15) * 1.6956);
+  height: calc(100%);
+  background-color: pink;
 `;

--- a/src/components/Scoreboard/ScoreboardBox.styled.js
+++ b/src/components/Scoreboard/ScoreboardBox.styled.js
@@ -15,11 +15,8 @@ export const ScoreboardBox = styled(Box)`
   border: inset 10px hsl(0deg 0% 92%);
   margin: calc(85% * 0.03) calc(100% * 0.03) 0 calc(100% * 0.03); // to be equal to the board
   background-color: hsl(0, 0%, 75%);
-`;
 
-export const BombsBox = styled(Box)`
-  // 100 * 1.15 to get 100% of the height and then * 1.6956 as that is the ratio 78:46.
-  width: calc(((100% * 1.15) * 0.15) * 1.6956);
-  height: calc(100%);
-  background-color: pink;
+  @media (max-width: 700px) {
+    padding: 3px;
+  }
 `;

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -31,5 +31,14 @@ export const Timer = (props) => {
     }, 10);
   };
 
-  return <div>{timerSeconds}</div>;
+  return (
+    <div>
+      {/* Going to use timerSeconds.split.map((curr) => `counter_${curr}` ) */}
+      {/* log the split to check */}
+      {timerSeconds}
+      {timerSeconds}
+      {timerSeconds}
+      {timerSeconds}
+    </div>
+  );
 };

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -1,5 +1,33 @@
 import React, { useState, useEffect, useRef } from "react";
 
+import { TimerBox, Counter } from "../Timer/Timer.styled";
+
+import counter_0 from "../../assets/counter_0.png";
+import counter_1 from "../../assets/counter_1.png";
+import counter_2 from "../../assets/counter_2.png";
+import counter_3 from "../../assets/counter_3.png";
+import counter_4 from "../../assets/counter_4.png";
+import counter_5 from "../../assets/counter_5.png";
+import counter_6 from "../../assets/counter_6.png";
+import counter_7 from "../../assets/counter_7.png";
+import counter_8 from "../../assets/counter_8.png";
+import counter_9 from "../../assets/counter_9.png";
+import counter_null from "../../assets/counter_null.png";
+
+const importedImage = {
+  counter_0,
+  counter_1,
+  counter_2,
+  counter_3,
+  counter_4,
+  counter_5,
+  counter_6,
+  counter_7,
+  counter_8,
+  counter_9,
+  counter_null,
+};
+
 export const Timer = (props) => {
   const [timerSeconds, setTimerSeconds] = useState("000.00");
 
@@ -32,13 +60,27 @@ export const Timer = (props) => {
   };
 
   return (
-    <div>
-      {/* Going to use timerSeconds.split.map((curr) => `counter_${curr}` ) */}
-      {/* log the split to check */}
-      {timerSeconds}
-      {timerSeconds}
-      {timerSeconds}
-      {timerSeconds}
-    </div>
+    <TimerBox>
+      <Counter
+        src={importedImage[`counter_${timerSeconds.charAt(0)}`]} // turns into array to be able to select a char string
+        alt={timerSeconds.charAt(0)}
+      />
+      <Counter
+        src={importedImage[`counter_${timerSeconds.charAt(1)}`]}
+        alt={timerSeconds.charAt(1)}
+      />
+      <Counter
+        src={importedImage[`counter_${timerSeconds.charAt(2)}`]}
+        alt={timerSeconds.charAt(2)}
+      />
+      <Counter
+        src={importedImage[`counter_${timerSeconds.charAt(4)}`]} // skips the dot - will fix later
+        alt={timerSeconds.charAt(4)}
+      />
+      <Counter
+        src={importedImage[`counter_${timerSeconds.charAt(5)}`]}
+        alt={timerSeconds.charAt(5)}
+      />
+    </TimerBox>
   );
 };

--- a/src/components/Timer/Timer.styled.js
+++ b/src/components/Timer/Timer.styled.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+import { Box } from "../Box/index";
+
+export const TimerBox = styled(Box)`
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: black;
+  padding: 0.5%;
+`;
+
+export const Counter = styled.img`
+  height: calc(100% - 4px);
+  margin: 0 2px;
+  image-rendering: pixelated;
+`;


### PR DESCRIPTION
Closes #34 

---

- In BombsDisplay it transforms the numbers into 3 integers, meaning 1 -> 001 and 10 -> 010 with the use of toString. (in strict mode 020 turns to 20)
- Updates the visual of the counter by returning the adequate image to the received value
- Cleans out useless wrappers
- Improves the sizing. Only the height is needed on the containers as the content being images define the width required. The images maintain their aspect ratio when given a single height or width value.
- Adds a very basic emote as reset that will need to be improved to a proper button.