### PR TITLE
Visual updates to emote button, borders size and millisecond timer spacing

### DIFF
--- a/src/components/Board/Board.styled.js
+++ b/src/components/Board/Board.styled.js
@@ -8,6 +8,6 @@ export const BoardStyled = styled(Box)`
   width: calc(100% - (100% * 0.06));
   height: calc(85% - (85% * 0.06));
   margin: calc(85% * 0.03) calc(100% * 0.03);
-  border: inset 10px hsl(0deg 0% 92%);
+  border: inset 6px hsl(0deg 0% 92%);
   background-color: lightgray;
 `;

--- a/src/components/BombsDisplay/BombsDisplay.styled.js
+++ b/src/components/BombsDisplay/BombsDisplay.styled.js
@@ -3,11 +3,14 @@ import styled from "styled-components";
 import { Box } from "../Box";
 
 export const BombsBox = styled(Box)`
+  box-sizing: border-box;
   align-items: center;
   justify-content: center;
   height: 100%;
-  background-color: black;
   padding: 0.5%;
+  border: inset 3px hsl(0 0% 92%);
+  background-color: black;
+  user-select: none;
 `;
 
 export const BombsImg = styled.img`

--- a/src/components/Cell/Cell.styled.js
+++ b/src/components/Cell/Cell.styled.js
@@ -19,7 +19,7 @@ export const CellStyled = styled(Box)`
   border: ${(props) =>
     props.pressed
       ? "solid 2px hsl(0, 0%, 60%)"
-      : "outset 7px hsl(0deg 0% 92%)"};
+      : "outset 4px hsl(0deg 0% 92%)"};
 `;
 
 export const Icons = styled.img`

--- a/src/components/Game/Game.styled.js
+++ b/src/components/Game/Game.styled.js
@@ -7,10 +7,10 @@ export const GameBox = styled(Box)`
   width: 100vw;
   height: calc(100vw * 1.15);
   // 85% of its height. If changed here it needs to be changed in the child components (Scoreboard and board) as they have it hardcoded as 15% and 85%.
-  max-width: calc(700px);
+  max-width: calc(450px);
   max-height: calc(
-    700px + 700px * 0.15
+    450px + (450px * 0.15)
   ); // plus 15% in height of the total width for the scoreboard
-  border: 10px outset hsl(0deg 0% 92%);
+  border: 8px outset hsl(0deg 0% 92%);
   background-color: hsl(0deg 0% 74%);
 `;

--- a/src/components/Scoreboard/Scoreboard.jsx
+++ b/src/components/Scoreboard/Scoreboard.jsx
@@ -4,7 +4,7 @@ import { BombsDisplay } from "../BombsDisplay/BombsDisplay";
 
 import { Timer } from "../Timer/Timer";
 
-import { ScoreboardBox } from "./ScoreboardBox.styled";
+import { ScoreboardBox, EmoteButton } from "./ScoreboardBox.styled";
 
 import face_waiting from "../../assets/face_waiting.png";
 
@@ -12,15 +12,17 @@ export const Scoreboard = ({ statusHandler, gameStatus, flaggedAmount }) => {
   return (
     <ScoreboardBox>
       <BombsDisplay flaggedAmount={flaggedAmount} />
-      {/* Reset Icon */}
-      <img
-        src={face_waiting}
-        alt={"reset"}
-        onClick={() => {
-          statusHandler("waiting");
-        }}
-        style={{ height: "100%", imageRendering: "pixelated" }}
-      />
+      <EmoteButton>
+        {/* Reset Icon */}
+        <img
+          src={face_waiting}
+          alt={"reset"}
+          onClick={() => {
+            statusHandler("waiting");
+          }}
+          style={{ height: "100%", imageRendering: "pixelated" }}
+        />
+      </EmoteButton>
       <Timer gameStatus={gameStatus} />
     </ScoreboardBox>
   );

--- a/src/components/Scoreboard/ScoreboardBox.styled.js
+++ b/src/components/Scoreboard/ScoreboardBox.styled.js
@@ -12,11 +12,22 @@ export const ScoreboardBox = styled(Box)`
   width: calc(100% - (100% * 0.06)); // amount added in margin
   height: 15%;
   padding: 1.5%;
-  border: inset 10px hsl(0deg 0% 92%);
+  border: inset 6px hsl(0deg 0% 92%);
   margin: calc(85% * 0.03) calc(100% * 0.03) 0 calc(100% * 0.03); // to be equal to the board
   background-color: hsl(0, 0%, 75%);
+`;
 
-  @media (max-width: 700px) {
-    padding: 3px;
+export const EmoteButton = styled.button`
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1%;
+  border: outset 4px hsl(0 0% 92%);
+  background-color: hsl(0 0% 74%);
+  user-select: none;
+
+  &:active {
+    border: inset 4px hsl(0 0% 92%);
   }
 `;

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -73,6 +73,11 @@ export const Timer = (props) => {
         src={importedImage[`counter_${timerSeconds.charAt(2)}`]}
         alt={timerSeconds.charAt(2)}
       />
+      {/* <div style={{ width: "15px" }} /> */}
+      <Counter
+        src={counter_null} // skips the dot - will fix later
+        alt={"-"}
+      />
       <Counter
         src={importedImage[`counter_${timerSeconds.charAt(4)}`]} // skips the dot - will fix later
         alt={timerSeconds.charAt(4)}

--- a/src/components/Timer/Timer.styled.js
+++ b/src/components/Timer/Timer.styled.js
@@ -3,15 +3,18 @@ import styled from "styled-components";
 import { Box } from "../Box/index";
 
 export const TimerBox = styled(Box)`
+  box-sizing: border-box;
   align-items: center;
   justify-content: center;
   height: 100%;
-  background-color: black;
   padding: 0.5%;
+  border: inset 3px hsl(0 0% 92%);
+  background-color: black;
 `;
 
 export const Counter = styled.img`
   height: calc(100% - 4px);
   margin: 0 2px;
   image-rendering: pixelated;
+  user-select: none;
 `;


### PR DESCRIPTION
Closes #36 

---

- Border size reduced as they where too large when compared to original minesweeper
- Adds missing borders to the bomb counter and the timer
- Reduces the size of the app to match original minesweeper more closely (still larger but not as much)
- **Emote button now matches the original with the borders and changes when `active`**
- Adds a spacing to the `Timer` numbers to be easier to distinguish the seconds from the milliseconds